### PR TITLE
Fix reversed HTML in output

### DIFF
--- a/src/Oak/Html.purs
+++ b/src/Oak/Html.purs
@@ -1,6 +1,6 @@
 module Oak.Html where
 
-import Data.Array (cons)
+import Data.Array (cons, reverse)
 import Oak.Html.Attribute (Attribute)
 import Oak.Html.Present (present, class Present)
 import Prelude
@@ -85,7 +85,7 @@ getBuilder = Builder $ \val ->
 
 runBuilder :: forall msg. View msg -> Array (Html msg)
 runBuilder (Builder b_a) = let T v new_s = b_a []
-                           in new_s
+                           in reverse new_s
 
 instance htmlFunctor :: Functor Html where
   map ::


### PR DESCRIPTION
### The problem:
Since new tags are `cons`'d to the beginning of the array of tags that
came prior, the HTML is actually built up in reverse order, producing reversed output.

![Selection_007](https://user-images.githubusercontent.com/2818781/72857863-e26b6b00-3c8c-11ea-9085-0d1f990a6679.png)

![Selection_008](https://user-images.githubusercontent.com/2818781/72857870-e5fef200-3c8c-11ea-860a-66089b939fdf.png)

### The Fix:
Reversing the output of `runBuilder` puts the tags in the correct order.

